### PR TITLE
Add displays-off idle stage

### DIFF
--- a/BarWidget.qml
+++ b/BarWidget.qml
@@ -51,7 +51,7 @@ BarWidget {
     bar: root.bar
     text: "󰒲"
     tooltipText: root.sandmanService
-      ? Model.statusSummary(root.sandmanService.screensaverSeconds, root.sandmanService.lockSeconds, root.sandmanService.sleepSeconds)
+      ? Model.statusSummary(root.sandmanService.screensaverSeconds, root.sandmanService.displaySeconds, root.sandmanService.lockSeconds, root.sandmanService.sleepSeconds)
       : "Sandman"
     onPressed: function(buttonCode) {
       if (buttonCode === Qt.LeftButton) root.toggle()

--- a/Model.js
+++ b/Model.js
@@ -1,6 +1,7 @@
 .pragma library
 
 var screensaverPresets = [0, 60, 120, 300, 600, 900, 1800]
+var displayPresets = [0, 60, 120, 300, 600, 900, 1800]
 var lockPresets = [0, 300, 600, 900, 1800, 3600]
 var sleepPresets = [0, 900, 1800, 3600, 7200]
 
@@ -19,6 +20,7 @@ function parseConfig(raw) {
 
   return {
     screensaver: normalizedSeconds(parsed.screensaver, 150, true),
+    display: normalizedSeconds(parsed.display, 0, true),
     lock: normalizedSeconds(parsed.lock, 300, true),
     sleep: normalizedSeconds(parsed.sleep, 0, true)
   }
@@ -62,8 +64,9 @@ function customSeconds(hours, minutes) {
   return (safeHours * 60 + safeMinutes) * 60
 }
 
-function statusSummary(screensaver, lock, sleep) {
+function statusSummary(screensaver, display, lock, sleep) {
   return "Screen " + formatDuration(screensaver)
+    + " · Displays " + formatDuration(display)
     + " · Lock " + formatDuration(lock)
     + " · Sleep " + formatDuration(sleep)
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -16,15 +16,20 @@ Panel {
   readonly property color contentForeground: bar ? bar.foreground : Color.foreground
   readonly property string contentFontFamily: bar ? bar.fontFamily : Style.font.family
   readonly property int screensaverSeconds: sandmanService ? sandmanService.screensaverSeconds : 150
+  readonly property int displaySeconds: sandmanService ? sandmanService.displaySeconds : 0
   readonly property int lockSeconds: sandmanService ? sandmanService.lockSeconds : 300
   readonly property int sleepSeconds: sandmanService ? sandmanService.sleepSeconds : 0
   readonly property bool saving: sandmanService ? sandmanService.saving : false
   readonly property bool screensaverUsesPreset: Model.isPreset(screensaverSeconds, Model.screensaverPresets)
+  readonly property bool displayUsesPreset: Model.isPreset(displaySeconds, Model.displayPresets)
   readonly property bool lockUsesPreset: Model.isPreset(lockSeconds, Model.lockPresets)
   readonly property bool sleepUsesPreset: Model.isPreset(sleepSeconds, Model.sleepPresets)
   property bool customEditorOpen: false
   property int customHours: 0
   property int customMinutes: 1
+  property bool customDisplayEditorOpen: false
+  property int customDisplayHours: 0
+  property int customDisplayMinutes: 5
   property bool customLockEditorOpen: false
   property int customLockHours: 0
   property int customLockMinutes: 5
@@ -32,6 +37,7 @@ Panel {
   property int customSleepHours: 0
   property int customSleepMinutes: 15
   readonly property int customTimeoutSeconds: Model.customSeconds(customHours, customMinutes)
+  readonly property int customDisplayTimeoutSeconds: Model.customSeconds(customDisplayHours, customDisplayMinutes)
   readonly property int customLockTimeoutSeconds: Model.customSeconds(customLockHours, customLockMinutes)
   readonly property int customSleepTimeoutSeconds: Model.customSeconds(customSleepHours, customSleepMinutes)
 
@@ -67,6 +73,30 @@ Panel {
 
   function applyCustomTimeout() {
     if (root.customTimeoutSeconds > 0) root.setScreensaver(root.customTimeoutSeconds)
+  }
+
+  function setDisplay(value) {
+    if (root.sandmanService) root.sandmanService.setDisplay(value)
+  }
+
+  function selectDisplayPreset(value) {
+    root.customDisplayEditorOpen = false
+    root.setDisplay(value)
+  }
+
+  function loadCustomDisplayTimeout() {
+    var parts = Model.customParts(root.displaySeconds > 0 ? root.displaySeconds : 300)
+    root.customDisplayHours = parts.hours
+    root.customDisplayMinutes = parts.minutes
+  }
+
+  function openCustomDisplayEditor() {
+    root.loadCustomDisplayTimeout()
+    root.customDisplayEditorOpen = true
+  }
+
+  function applyCustomDisplayTimeout() {
+    if (root.customDisplayTimeoutSeconds > 0) root.setDisplay(root.customDisplayTimeoutSeconds)
   }
 
   function setLock(value) {
@@ -120,9 +150,11 @@ Panel {
   onOpenedChanged: {
     if (!opened) return
     root.customEditorOpen = !root.screensaverUsesPreset
+    root.customDisplayEditorOpen = !root.displayUsesPreset
     root.customLockEditorOpen = !root.lockUsesPreset
     root.customSleepEditorOpen = !root.sleepUsesPreset
     if (root.customEditorOpen) root.loadCustomTimeout()
+    if (root.customDisplayEditorOpen) root.loadCustomDisplayTimeout()
     if (root.customLockEditorOpen) root.loadCustomLockTimeout()
     if (root.customSleepEditorOpen) root.loadCustomSleepTimeout()
   }
@@ -173,7 +205,7 @@ Panel {
             }
 
             Text {
-              text: Model.statusSummary(root.screensaverSeconds, root.lockSeconds, root.sleepSeconds)
+              text: Model.statusSummary(root.screensaverSeconds, root.displaySeconds, root.lockSeconds, root.sleepSeconds)
               color: Util.alpha(root.contentForeground, 0.64)
               font.family: root.contentFontFamily
               font.pixelSize: Style.font.caption
@@ -286,6 +318,118 @@ Panel {
               && root.lockSeconds <= root.screensaverSeconds
             width: parent.width
             text: "Auto-lock is set before the screen saver can appear."
+            color: Color.urgent
+            font.family: root.contentFontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
+          }
+        }
+
+        PanelSeparator { width: parent.width }
+
+        Column {
+          width: parent.width
+          spacing: Style.space(7)
+
+          PanelSectionHeader {
+            width: parent.width
+            text: "DISPLAYS OFF"
+            foreground: root.contentForeground
+            fontFamily: root.contentFontFamily
+          }
+
+          Text {
+            width: parent.width
+            text: "Turn off the displays after inactivity"
+            color: Util.alpha(root.contentForeground, 0.64)
+            font.family: root.contentFontFamily
+            font.pixelSize: Style.font.caption
+          }
+
+          Grid {
+            id: displayGrid
+            width: parent.width
+            columns: 3
+            columnSpacing: Style.space(6)
+            rowSpacing: Style.space(6)
+
+            Repeater {
+              model: Model.displayPresets
+
+              Button {
+                required property var modelData
+                width: (displayGrid.width - displayGrid.columnSpacing * 2) / 3
+                text: Model.formatDuration(modelData)
+                selected: !root.customDisplayEditorOpen
+                  && root.displaySeconds === Number(modelData)
+                enabled: !root.saving
+                focusable: true
+                bordered: true
+                foreground: root.contentForeground
+                fontFamily: root.contentFontFamily
+                onClicked: root.selectDisplayPreset(Number(modelData))
+              }
+            }
+
+            Button {
+              width: (displayGrid.width - displayGrid.columnSpacing * 2) / 3
+              text: "Custom"
+              selected: root.customDisplayEditorOpen || !root.displayUsesPreset
+              enabled: !root.saving
+              focusable: true
+              bordered: true
+              foreground: root.contentForeground
+              fontFamily: root.contentFontFamily
+              onClicked: root.openCustomDisplayEditor()
+            }
+          }
+
+          Row {
+            visible: root.customDisplayEditorOpen
+            width: parent.width
+            spacing: Style.space(8)
+
+            NumberField {
+              label: "Hours"
+              value: root.customDisplayHours
+              from: 0
+              to: 24
+              fieldWidth: Style.space(104)
+              foreground: root.contentForeground
+              fontFamily: root.contentFontFamily
+              onModified: function(value) { root.customDisplayHours = value }
+            }
+
+            NumberField {
+              label: "Minutes"
+              value: root.customDisplayMinutes
+              from: 0
+              to: 59
+              fieldWidth: Style.space(104)
+              foreground: root.contentForeground
+              fontFamily: root.contentFontFamily
+              onModified: function(value) { root.customDisplayMinutes = value }
+            }
+
+            Button {
+              anchors.bottom: parent.bottom
+              width: parent.width - x
+              text: "Apply"
+              enabled: !root.saving && root.customDisplayTimeoutSeconds > 0
+              focusable: true
+              bordered: true
+              foreground: root.contentForeground
+              fontFamily: root.contentFontFamily
+              onClicked: root.applyCustomDisplayTimeout()
+            }
+          }
+
+          Text {
+            visible: root.screensaverSeconds > 0
+              && root.displaySeconds > 0
+              && root.displaySeconds <= root.screensaverSeconds
+            width: parent.width
+            text: "Displays turn off before the screen saver can appear."
             color: Color.urgent
             font.family: root.contentFontFamily
             font.pixelSize: Style.font.caption

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ Set when your screen rests, locks, and sleeps from the Omarchy Quattro bar.
 
 ![Sandman screensaver, auto-lock, and sleep settings](preview.png)
 
-Sandman provides three simple controls:
+Sandman provides four simple controls:
 
 - **Screen saver** — starts the screen saver after the selected period of inactivity.
+- **Displays off** — turns the displays off (DPMS) after the selected period of inactivity while respecting idle inhibitors.
 - **Auto-lock** — locks the session after the selected period of inactivity.
 - **Sleep** — suspends the computer after the selected period of inactivity while respecting idle inhibitors.
 
@@ -26,9 +27,13 @@ omarchy bar plugin add lgse.sandman --section right
 
 ## Usage
 
-Click the Zzz icon in the bar and choose a timeout for each stage. Presets apply immediately; Custom accepts hours and minutes and applies on confirmation for screen saver, auto-lock, and sleep. Existing values that do not match a preset—including Omarchy's 2½-minute screen-saver default—open as Custom. Changes survive shell reloads and reboots.
+Click the Zzz icon in the bar and choose a timeout for each stage. Presets apply immediately; Custom accepts hours and minutes and applies on confirmation for screen saver, displays off, auto-lock, and sleep. Existing values that do not match a preset—including Omarchy's 2½-minute screen-saver default—open as Custom. Changes survive shell reloads and reboots.
 
-Sandman stores its state in `~/.config/omarchy/sandman.json`. The effective screen-saver and auto-lock values remain in Omarchy's standard `~/.config/omarchy/shell.json`.
+Sandman stores its state in `~/.config/omarchy/sandman.json`. The effective screen-saver and auto-lock values remain in Omarchy's standard `~/.config/omarchy/shell.json`; the displays-off and sleep timers are handled by Sandman itself and are not written there.
+
+## How displays off works
+
+Sandman uses Quickshell's idle monitor with inhibitor support and turns the displays off through Hyprland's `dpms` dispatcher. Applications holding an idle inhibitor can prevent the timer from firing, and any key press or mouse movement turns the displays back on.
 
 ## How sleep works
 

--- a/Service.qml
+++ b/Service.qml
@@ -9,10 +9,11 @@ Item {
   id: root
 
   property var shell: null
-  property var configState: ({ screensaver: 150, lock: 300, sleep: 0 })
+  property var configState: ({ screensaver: 150, display: 0, lock: 300, sleep: 0 })
   property bool saving: false
   property string lastError: ""
   property bool suspendPending: false
+  property bool displaysOff: false
   property bool idleCycleRunning: false
   property var screensaverWindows: ({})
   property int screensaverWindowCount: 0
@@ -21,12 +22,24 @@ Item {
   readonly property string configPath: home + "/.config/omarchy/sandman.json"
   readonly property string screensaverClass: "org.omarchy.screensaver"
   readonly property int screensaverSeconds: Model.normalizedSeconds(configState.screensaver, 150, true)
+  readonly property int displaySeconds: Model.normalizedSeconds(configState.display, 0, true)
   readonly property int lockSeconds: Model.normalizedSeconds(configState.lock, 300, true)
   readonly property int sleepSeconds: Model.normalizedSeconds(configState.sleep, 0, true)
+  readonly property bool displayEnabled: displaySeconds > 0
   readonly property bool sleepEnabled: sleepSeconds > 0
-  readonly property int firstIdleSeconds: sleepEnabled
-    ? (screensaverSeconds > 0 ? Math.min(screensaverSeconds, sleepSeconds) : sleepSeconds)
-    : 1
+  // The screensaver, display-off, and sleep stages are all self-observed here so
+  // the cycle can survive the screensaver's brief activity blip (see below). The
+  // shared monitor fires at the earliest of the enabled stage boundaries.
+  readonly property bool cycleEnabled: displayEnabled || sleepEnabled
+  readonly property int firstIdleSeconds: {
+    if (!cycleEnabled) return 1
+    var candidates = []
+    if (screensaverSeconds > 0) candidates.push(screensaverSeconds)
+    if (displayEnabled) candidates.push(displaySeconds)
+    if (sleepEnabled) candidates.push(sleepSeconds)
+    return Math.min.apply(Math, candidates)
+  }
+  readonly property int displayDelaySeconds: displayEnabled ? Math.max(0, displaySeconds - firstIdleSeconds) : 0
   readonly property int sleepDelaySeconds: sleepEnabled ? Math.max(0, sleepSeconds - firstIdleSeconds) : 0
   readonly property string helperPath: {
     var url = String(Qt.resolvedUrl("sandman.py"))
@@ -48,6 +61,10 @@ Item {
 
   function setLock(seconds) {
     return runHelper(["set-lock", String(seconds)])
+  }
+
+  function setDisplay(seconds) {
+    return runHelper(["set-display", String(seconds)])
   }
 
   function setSleep(seconds) {
@@ -94,33 +111,54 @@ Item {
   }
 
   function startIdleCycle() {
-    if (!root.sleepEnabled || root.idleCycleRunning) return
+    if (!root.cycleEnabled || root.idleCycleRunning) return
     root.idleCycleRunning = true
     resetScreensaverWindows()
 
-    if (root.sleepDelaySeconds === 0) requestSuspend()
-    else {
-      sleepTimer.restart()
-      // Omarchy starts the screensaver at this same idle boundary. It briefly
-      // reports compositor activity while opening, so allow its window event
-      // to arrive before deciding that the user really returned.
-      if (root.screensaverSeconds > 0 && root.firstIdleSeconds === root.screensaverSeconds)
-        screensaverGrace.restart()
+    // Omarchy starts the screensaver at this same idle boundary. It briefly
+    // reports compositor activity while opening, so allow its window event
+    // to arrive before deciding that the user really returned.
+    if (root.screensaverSeconds > 0 && root.firstIdleSeconds === root.screensaverSeconds)
+      screensaverGrace.restart()
+
+    if (root.displayEnabled) {
+      if (root.displayDelaySeconds === 0) turnDisplaysOff()
+      else displayTimer.restart()
+    }
+
+    if (root.sleepEnabled) {
+      if (root.sleepDelaySeconds === 0) requestSuspend()
+      else sleepTimer.restart()
     }
   }
 
   function cancelIdleCycle() {
+    displayTimer.stop()
     sleepTimer.stop()
     screensaverGrace.stop()
     root.idleCycleRunning = false
     resetScreensaverWindows()
+    if (root.displaysOff) turnDisplaysOn()
   }
 
   function handleIdleChanged() {
-    if (sleepMonitor.isIdle) startIdleCycle()
+    if (idleMonitor.isIdle) startIdleCycle()
     else if (root.idleCycleRunning
              && root.screensaverWindowCount === 0
              && !screensaverGrace.running) cancelIdleCycle()
+  }
+
+  function turnDisplaysOff() {
+    if (!root.displayEnabled || displayOffProcess.running) return
+    root.displaysOff = true
+    root.lastError = ""
+    displayOffProcess.running = true
+  }
+
+  function turnDisplaysOn() {
+    root.displaysOff = false
+    if (displayOnProcess.running) return
+    displayOnProcess.running = true
   }
 
   function requestSuspend() {
@@ -131,6 +169,7 @@ Item {
   }
 
   onScreensaverSecondsChanged: cancelIdleCycle()
+  onDisplaySecondsChanged: cancelIdleCycle()
   onSleepSecondsChanged: cancelIdleCycle()
 
   Process {
@@ -170,11 +209,18 @@ Item {
   }
 
   IdleMonitor {
-    id: sleepMonitor
-    enabled: root.sleepEnabled
+    id: idleMonitor
+    enabled: root.cycleEnabled
     timeout: root.firstIdleSeconds
     respectInhibitors: true
     onIsIdleChanged: root.handleIdleChanged()
+  }
+
+  Timer {
+    id: displayTimer
+    interval: root.displayDelaySeconds * 1000
+    repeat: false
+    onTriggered: root.turnDisplaysOff()
   }
 
   Timer {
@@ -188,13 +234,32 @@ Item {
     id: screensaverGrace
     interval: 3000
     repeat: false
-    onTriggered: if (root.idleCycleRunning && !sleepMonitor.isIdle
+    onTriggered: if (root.idleCycleRunning && !idleMonitor.isIdle
                      && root.screensaverWindowCount === 0) root.cancelIdleCycle()
   }
 
   Connections {
     target: Hyprland
     function onRawEvent(event) { root.handleHyprlandEvent(event) }
+  }
+
+  // Hyprland's Lua config parses `hyprctl dispatch` args as Lua, so the classic
+  // `dpms off` form is a syntax error there; use the `hl.dsp` shorthand and fall
+  // back to the classic form for older Hyprland, mirroring omarchy-launch-screensaver.
+  Process {
+    id: displayOffProcess
+    command: ["bash", "-lc", "hyprctl dispatch 'hl.dsp.dpms(\"off\")' || hyprctl dispatch dpms off"]
+    onExited: function(exitCode) {
+      if (exitCode !== 0) {
+        root.displaysOff = false
+        root.lastError = "Could not turn the displays off"
+      }
+    }
+  }
+
+  Process {
+    id: displayOnProcess
+    command: ["bash", "-lc", "hyprctl dispatch 'hl.dsp.dpms(\"on\")' || hyprctl dispatch dpms on"]
   }
 
   Process {
@@ -214,10 +279,13 @@ Item {
     function status(): string {
       return JSON.stringify({
         screensaver: root.screensaverSeconds,
+        display: root.displaySeconds,
         lock: root.lockSeconds,
         sleep: root.sleepSeconds,
-        idle: sleepMonitor.isIdle,
+        idle: idleMonitor.isIdle,
         idleCycleRunning: root.idleCycleRunning,
+        displayDelay: root.displayDelaySeconds,
+        displaysOff: root.displaysOff,
         sleepDelay: root.sleepDelaySeconds,
         screensaverWindows: root.screensaverWindowCount,
         saving: root.saving,
@@ -227,6 +295,7 @@ Item {
     }
 
     function setScreensaver(seconds: int): bool { return root.setScreensaver(seconds) }
+    function setDisplay(seconds: int): bool { return root.setDisplay(seconds) }
     function setLock(seconds: int): bool { return root.setLock(seconds) }
     function setSleep(seconds: int): bool { return root.setSleep(seconds) }
     function refresh(): void { root.refresh() }

--- a/Service.qml
+++ b/Service.qml
@@ -115,11 +115,16 @@ Item {
     root.idleCycleRunning = true
     resetScreensaverWindows()
 
-    // Omarchy starts the screensaver at this same idle boundary. It briefly
-    // reports compositor activity while opening, so allow its window event
-    // to arrive before deciding that the user really returned.
-    if (root.screensaverSeconds > 0 && root.firstIdleSeconds === root.screensaverSeconds)
-      screensaverGrace.restart()
+    // Omarchy starts the screensaver at the screensaver boundary. It briefly
+    // reports compositor activity while opening, so allow its window event to
+    // arrive before deciding that the user really returned. Arm the grace now if
+    // the screensaver is the first stage, otherwise schedule it for the later
+    // screensaver boundary (e.g. Display=2m, Screensaver=5m) so launching it
+    // then does not cancel the cycle and turn the displays back on.
+    if (root.screensaverSeconds > 0) {
+      if (root.firstIdleSeconds === root.screensaverSeconds) screensaverGrace.restart()
+      else screensaverBoundaryTimer.restart()
+    }
 
     if (root.displayEnabled) {
       if (root.displayDelaySeconds === 0) turnDisplaysOff()
@@ -136,6 +141,7 @@ Item {
     displayTimer.stop()
     sleepTimer.stop()
     screensaverGrace.stop()
+    screensaverBoundaryTimer.stop()
     root.idleCycleRunning = false
     resetScreensaverWindows()
     if (root.displaysOff) turnDisplaysOn()
@@ -238,6 +244,16 @@ Item {
                      && root.screensaverWindowCount === 0) root.cancelIdleCycle()
   }
 
+  // When the screensaver boundary comes after the first idle stage (e.g. displays
+  // off before the screensaver), arm the grace as that boundary arrives so the
+  // screensaver launch's brief activity does not cancel the cycle.
+  Timer {
+    id: screensaverBoundaryTimer
+    interval: Math.max(0, root.screensaverSeconds - root.firstIdleSeconds) * 1000
+    repeat: false
+    onTriggered: if (root.idleCycleRunning) screensaverGrace.restart()
+  }
+
   Connections {
     target: Hyprland
     function onRawEvent(event) { root.handleHyprlandEvent(event) }
@@ -246,9 +262,12 @@ Item {
   // Hyprland's Lua config parses `hyprctl dispatch` args as Lua, so the classic
   // `dpms off` form is a syntax error there; use the `hl.dsp` shorthand and fall
   // back to the classic form for older Hyprland, mirroring omarchy-launch-screensaver.
+  // The action MUST be passed as a table (`{ action = "off" }`); a bare string is
+  // treated as the default *toggle*, so an explicit "on" after input already woke
+  // the displays would toggle them back off.
   Process {
     id: displayOffProcess
-    command: ["bash", "-lc", "hyprctl dispatch 'hl.dsp.dpms(\"off\")' || hyprctl dispatch dpms off"]
+    command: ["bash", "-lc", "hyprctl dispatch 'hl.dsp.dpms({ action = \"off\" })' || hyprctl dispatch dpms off"]
     onExited: function(exitCode) {
       if (exitCode !== 0) {
         root.displaysOff = false
@@ -259,7 +278,7 @@ Item {
 
   Process {
     id: displayOnProcess
-    command: ["bash", "-lc", "hyprctl dispatch 'hl.dsp.dpms(\"on\")' || hyprctl dispatch dpms on"]
+    command: ["bash", "-lc", "hyprctl dispatch 'hl.dsp.dpms({ action = \"on\" })' || hyprctl dispatch dpms on"]
   }
 
   Process {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "lgse.sandman",
   "name": "Sandman",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "Pierre Berube",
   "license": "MIT",
   "description": "Set when your screen rests, locks, and sleeps.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandman",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Set when your screen rests, locks, and sleeps.",
   "scripts": {

--- a/sandman.py
+++ b/sandman.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_SCREENSAVER = 150
+DEFAULT_DISPLAY = 0
 DEFAULT_LOCK = 300
 DEFAULT_SLEEP = 0
 OFF_TIMEOUT = 7 * 24 * 60 * 60
@@ -81,6 +82,7 @@ def current_config() -> dict[str, int]:
     )
     return {
         "screensaver": stored_screensaver,
+        "display": seconds(stored.get("display"), DEFAULT_DISPLAY, allow_off=True),
         "lock": stored_lock,
         "sleep": seconds(stored.get("sleep"), DEFAULT_SLEEP, allow_off=True),
     }
@@ -126,6 +128,14 @@ def set_lock(value: int) -> dict[str, int]:
     return config
 
 
+def set_display(value: int) -> dict[str, int]:
+    value = seconds(value, DEFAULT_DISPLAY, allow_off=True)
+    config = current_config()
+    config["display"] = value
+    atomic_write(config_path(), config)
+    return config
+
+
 def set_sleep(value: int) -> dict[str, int]:
     value = seconds(value, DEFAULT_SLEEP, allow_off=True)
     config = current_config()
@@ -141,6 +151,8 @@ def parser() -> argparse.ArgumentParser:
     commands.add_parser("get")
     screensaver = commands.add_parser("set-screensaver")
     screensaver.add_argument("seconds", type=int)
+    display = commands.add_parser("set-display")
+    display.add_argument("seconds", type=int)
     lock = commands.add_parser("set-lock")
     lock.add_argument("seconds", type=int)
     sleep = commands.add_parser("set-sleep")
@@ -156,6 +168,8 @@ def main() -> int:
         config = current_config()
     elif args.command == "set-screensaver":
         config = set_screensaver(args.seconds)
+    elif args.command == "set-display":
+        config = set_display(args.seconds)
     elif args.command == "set-lock":
         config = set_lock(args.seconds)
     else:

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -11,12 +11,12 @@ vm.runInContext(source, model);
 
 test("parseConfig normalizes persisted values", () => {
   assert.deepEqual(
-    JSON.parse(JSON.stringify(model.parseConfig('{"screensaver":600,"lock":900,"sleep":3600}'))),
-    { screensaver: 600, lock: 900, sleep: 3600 }
+    JSON.parse(JSON.stringify(model.parseConfig('{"screensaver":600,"display":120,"lock":900,"sleep":3600}'))),
+    { screensaver: 600, display: 120, lock: 900, sleep: 3600 }
   );
   assert.deepEqual(
     JSON.parse(JSON.stringify(model.parseConfig("broken"))),
-    { screensaver: 150, lock: 300, sleep: 0 }
+    { screensaver: 150, display: 0, lock: 300, sleep: 0 }
   );
 });
 
@@ -29,7 +29,7 @@ test("formatDuration produces compact labels", () => {
 
 test("statusSummary includes all stages", () => {
   assert.equal(
-    model.statusSummary(300, 600, 1800),
-    "Screen 5 min · Lock 10 min · Sleep 30 min"
+    model.statusSummary(300, 120, 600, 1800),
+    "Screen 5 min · Displays 2 min · Lock 10 min · Sleep 30 min"
   );
 });

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -40,17 +40,17 @@ class SandmanHelperTest(unittest.TestCase):
         return json.loads(completed.stdout)
 
     def test_init_inherits_omarchy_idle_settings_and_disables_sleep(self):
-        expected = {"screensaver": 150, "lock": 300, "sleep": 0}
+        expected = {"screensaver": 150, "display": 0, "lock": 300, "sleep": 0}
         self.assertEqual(self.run_helper("init"), expected)
         self.assertEqual(json.loads(self.config.read_text()), expected)
 
-    def test_init_migrates_existing_config_to_include_lock(self):
+    def test_init_migrates_existing_config_to_include_new_fields(self):
         self.config.write_text(
             json.dumps({"screensaver": 150, "sleep": 3600, "lockDelay": 150}),
             encoding="utf-8",
         )
 
-        expected = {"screensaver": 150, "lock": 300, "sleep": 3600}
+        expected = {"screensaver": 150, "display": 0, "lock": 300, "sleep": 3600}
         self.assertEqual(self.run_helper("init"), expected)
         self.assertEqual(json.loads(self.config.read_text()), expected)
 
@@ -58,7 +58,7 @@ class SandmanHelperTest(unittest.TestCase):
         self.run_helper("init")
         self.assertEqual(
             self.run_helper("set-screensaver", "600"),
-            {"screensaver": 600, "lock": 300, "sleep": 0},
+            {"screensaver": 600, "display": 0, "lock": 300, "sleep": 0},
         )
         shell = json.loads(self.shell.read_text())
         self.assertEqual(shell["idle"], {"screensaver": 600, "lock": 300})
@@ -68,7 +68,7 @@ class SandmanHelperTest(unittest.TestCase):
         self.run_helper("init")
         self.assertEqual(
             self.run_helper("set-lock", "900"),
-            {"screensaver": 150, "lock": 900, "sleep": 0},
+            {"screensaver": 150, "display": 0, "lock": 900, "sleep": 0},
         )
         shell = json.loads(self.shell.read_text())
         self.assertEqual(shell["idle"], {"screensaver": 150, "lock": 900})
@@ -78,7 +78,7 @@ class SandmanHelperTest(unittest.TestCase):
         self.run_helper("set-lock", "0")
         self.assertEqual(
             self.run_helper("set-screensaver", "0"),
-            {"screensaver": 0, "lock": 0, "sleep": 0},
+            {"screensaver": 0, "display": 0, "lock": 0, "sleep": 0},
         )
         shell = json.loads(self.shell.read_text())
         self.assertEqual(
@@ -91,7 +91,16 @@ class SandmanHelperTest(unittest.TestCase):
         before = self.shell.read_text()
         self.assertEqual(
             self.run_helper("set-sleep", "3600"),
-            {"screensaver": 150, "lock": 300, "sleep": 3600},
+            {"screensaver": 150, "display": 0, "lock": 300, "sleep": 3600},
+        )
+        self.assertEqual(self.shell.read_text(), before)
+
+    def test_display_only_changes_sandman_state(self):
+        self.run_helper("init")
+        before = self.shell.read_text()
+        self.assertEqual(
+            self.run_helper("set-display", "300"),
+            {"screensaver": 150, "display": 300, "lock": 300, "sleep": 0},
         )
         self.assertEqual(self.shell.read_text(), before)
 


### PR DESCRIPTION
Hi there, thanks for Sandman. I wanted a way to customize when my monitors turn off (I never use screensaver/lock) so I customized Sandman and then thought to contribute it back. 

Hope you find it useful. I worked on this with Claude, since I am not familiar with Quickshell and Python.

Here is a screenshot of it in action, I went with the same defaults of the other features:

<img width="729" height="1243" alt="image" src="https://github.com/user-attachments/assets/f0671a01-4f18-4acf-8337-d742a847ca06" />

Following is Claude's original PR text:

---

Adds a fourth stage to Sandman: turn the displays off (DPMS) after a configurable timeout, sitting between the screen saver and auto-lock in the panel.

Built to match the existing stages:

- self-managed like Sleep, own timeout with presets + custom, Off by default, stored in `sandman.json`, nothing written to `shell.json`
- folded into the same idle cycle as Sleep so it survives the screensaver's brief activity blip (shared first-idle monitor + per-stage delay timers)
- respects idle inhibitors, any key press or mouse move wakes the displays back on

One Quattro-specific thing worth a look: Hyprland's lua config parses `hyprctl dispatch` args as lua, so the classic `dpms off` form is a syntax error there. I use the `hl.dsp.dpms("off")` shorthand (same pattern as `omarchy-launch-screensaver`) with a fallback to the classic form for older setups.

Also bumped the README (three → four controls) and extended both the node and python tests to cover the new field. `npm test` passes.

Happy to adjust naming/placement/presets if you'd rather they sit elsewhere.