### PR TITLE
Fail closed on unreadable config and invalid timeouts

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -4,6 +4,21 @@ var screensaverPresets = [0, 60, 120, 300, 600, 900, 1800]
 var lockPresets = [0, 300, 600, 900, 1800, 3600]
 var sleepPresets = [0, 900, 1800, 3600, 7200]
 
+var maxTimeoutSeconds = 7 * 24 * 60 * 60
+
+// Validate a caller-supplied timeout, including one arriving over IPC.
+// Returns whole seconds in [0, maxTimeoutSeconds], or -1 when the value is
+// unusable. Callers must treat -1 as "reject" and never as 0: coercing a bad
+// value to 0 would read as "Off" and stand auto-lock down. The upper bound
+// keeps sleepDelaySeconds * 1000 inside a 32-bit int.
+function requestedSeconds(value) {
+  var number = Number(value)
+  if (!isFinite(number)) return -1
+  number = Math.round(number)
+  if (number < 0) return -1
+  return Math.min(number, maxTimeoutSeconds)
+}
+
 function normalizedSeconds(value, fallback, allowOff) {
   var number = Number(value)
   if (!isFinite(number)) return fallback

--- a/Model.js
+++ b/Model.js
@@ -9,22 +9,29 @@ var maxTimeoutSeconds = 7 * 24 * 60 * 60
 // Validate a caller-supplied timeout, including one arriving over IPC.
 // Returns whole seconds in [0, maxTimeoutSeconds], or -1 when the value is
 // unusable. Callers must treat -1 as "reject" and never as 0: coercing a bad
-// value to 0 would read as "Off" and stand auto-lock down. The upper bound
-// keeps sleepDelaySeconds * 1000 inside a 32-bit int.
+// value to 0 would read as "Off" and stand auto-lock down.
+//
+// Out-of-range values are rejected rather than clamped, matching the CLI. A
+// clamp would turn an absurd setLock into a seven-day timeout, which is the
+// same silent weakening this is meant to prevent.
 function requestedSeconds(value) {
   var number = Number(value)
   if (!isFinite(number)) return -1
   number = Math.round(number)
-  if (number < 0) return -1
-  return Math.min(number, maxTimeoutSeconds)
+  if (number < 0 || number > maxTimeoutSeconds) return -1
+  return number
 }
 
+// Normalize a value already on disk. Unlike requestedSeconds there is no caller
+// to report back to, so an oversized value is clamped rather than rejected -
+// the bound is what keeps sleepDelaySeconds * 1000 inside a 32-bit int.
 function normalizedSeconds(value, fallback, allowOff) {
   var number = Number(value)
   if (!isFinite(number)) return fallback
   number = Math.round(number)
   if (allowOff && number === 0) return 0
-  return number > 0 ? number : fallback
+  if (number <= 0) return fallback
+  return Math.min(number, maxTimeoutSeconds)
 }
 
 function parseConfig(raw) {

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ rm -f ~/.config/omarchy/sandman.json
 
 Removing Sandman does not revert the screen-saver and lock timeouts already written to `shell.json`.
 
+This matters if either setting was left **Off**. Off is stored in `shell.json` as a
+seven-day timeout, so removing Sandman while auto-lock is Off leaves a machine that
+effectively never locks, with no Sandman UI left to notice it. Set anything you want
+back on *before* removing, or restore Omarchy's defaults afterwards:
+
+```sh
+python3 - <<'PY'
+import json, pathlib
+path = pathlib.Path.home() / ".config/omarchy/shell.json"
+config = json.loads(path.read_text())
+config.setdefault("idle", {}).update({"screensaver": 150, "lock": 300})
+path.write_text(json.dumps(config, indent=2) + "\n")
+PY
+```
+
 ## License
 
 MIT

--- a/Service.qml
+++ b/Service.qml
@@ -42,16 +42,25 @@ Item {
     return true
   }
 
+  function runSetter(command, seconds) {
+    var value = Model.requestedSeconds(seconds)
+    if (value < 0) {
+      root.lastError = "Ignored an invalid timeout"
+      return false
+    }
+    return runHelper([command, String(value)])
+  }
+
   function setScreensaver(seconds) {
-    return runHelper(["set-screensaver", String(seconds)])
+    return runSetter("set-screensaver", seconds)
   }
 
   function setLock(seconds) {
-    return runHelper(["set-lock", String(seconds)])
+    return runSetter("set-lock", seconds)
   }
 
   function setSleep(seconds) {
-    return runHelper(["set-sleep", String(seconds)])
+    return runSetter("set-sleep", seconds)
   }
 
   function refresh() {
@@ -112,15 +121,28 @@ Item {
   function cancelIdleCycle() {
     sleepTimer.stop()
     screensaverGrace.stop()
+    screensaverStale.stop()
     root.idleCycleRunning = false
     resetScreensaverWindows()
   }
 
   function handleIdleChanged() {
-    if (sleepMonitor.isIdle) startIdleCycle()
-    else if (root.idleCycleRunning
-             && root.screensaverWindowCount === 0
-             && !screensaverGrace.running) cancelIdleCycle()
+    if (sleepMonitor.isIdle) {
+      screensaverStale.stop()
+      startIdleCycle()
+    } else if (root.idleCycleRunning
+               && root.screensaverWindowCount === 0
+               && !screensaverGrace.running) {
+      cancelIdleCycle()
+    } else if (root.idleCycleRunning && root.screensaverWindowCount > 0) {
+      // A window claiming the screensaver class is still tracked even though the
+      // user is active again. The window class is self-reported by any client and
+      // a closewindow event can be missed if the screensaver dies, so it must not
+      // hold the sleep timer open indefinitely - that would suspend the machine
+      // out from under an active user. Give the real screensaver a moment to
+      // close, then cancel regardless.
+      screensaverStale.restart()
+    }
   }
 
   function requestSuspend() {
@@ -190,6 +212,14 @@ Item {
     repeat: false
     onTriggered: if (root.idleCycleRunning && !sleepMonitor.isIdle
                      && root.screensaverWindowCount === 0) root.cancelIdleCycle()
+  }
+
+  // Backstop for tracked screensaver windows that outlive the user's return.
+  Timer {
+    id: screensaverStale
+    interval: 5000
+    repeat: false
+    onTriggered: if (root.idleCycleRunning && !sleepMonitor.isIdle) root.cancelIdleCycle()
   }
 
   Connections {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "lgse.sandman",
   "name": "Sandman",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "author": "Pierre Berube",
   "license": "MIT",
   "description": "Set when your screen rests, locks, and sleeps.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandman",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Set when your screen rests, locks, and sleeps.",
   "scripts": {

--- a/sandman.py
+++ b/sandman.py
@@ -47,7 +47,9 @@ def read_json(
         text = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return fallback.copy()
-    except OSError as error:
+    except (OSError, UnicodeError) as error:
+        # UnicodeDecodeError subclasses ValueError, not OSError, so a file
+        # holding invalid UTF-8 would otherwise escape as a traceback.
         if strict:
             raise ConfigError(f"Could not read {path}: {error}") from error
         return fallback.copy()
@@ -80,7 +82,12 @@ def seconds(value: Any, fallback: int, *, allow_off: bool = False) -> int:
         return fallback
     if allow_off and result == 0:
         return 0
-    return result if result > 0 else fallback
+    if result <= 0:
+        return fallback
+    # Bound persisted values too, not just setter input. A sandman.json written
+    # by an older version - or edited by hand - can hold a value large enough to
+    # overflow sleepDelaySeconds * 1000 in the QML timer.
+    return min(result, MAX_TIMEOUT)
 
 
 def atomic_write(path: Path, value: dict[str, Any]) -> None:

--- a/sandman.py
+++ b/sandman.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -14,6 +15,11 @@ DEFAULT_SCREENSAVER = 150
 DEFAULT_LOCK = 300
 DEFAULT_SLEEP = 0
 OFF_TIMEOUT = 7 * 24 * 60 * 60
+MAX_TIMEOUT = OFF_TIMEOUT
+
+
+class ConfigError(Exception):
+    """An existing config file could not be read, so we must not rewrite it."""
 
 
 def shell_path() -> Path:
@@ -26,12 +32,43 @@ def config_path() -> Path:
     return Path(override).expanduser() if override else Path.home() / ".config/omarchy/sandman.json"
 
 
-def read_json(path: Path, fallback: dict[str, Any]) -> dict[str, Any]:
+def read_json(
+    path: Path, fallback: dict[str, Any], *, strict: bool = False
+) -> dict[str, Any]:
+    """Load a JSON object, distinguishing "absent" from "present but unusable".
+
+    A missing file legitimately means "no settings yet", so the fallback applies.
+    Anything else - unreadable, malformed, or not a JSON object - means the file
+    holds content we failed to understand. When strict, refuse rather than return
+    a fallback: callers merge into the result and write it back, so returning a
+    fallback here would replace a config we could not read with a bare stub.
+    """
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-        return value if isinstance(value, dict) else fallback.copy()
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
         return fallback.copy()
+    except OSError as error:
+        if strict:
+            raise ConfigError(f"Could not read {path}: {error}") from error
+        return fallback.copy()
+
+    try:
+        value = json.loads(text)
+    except json.JSONDecodeError as error:
+        if strict:
+            raise ConfigError(
+                f"{path} is not valid JSON ({error}). "
+                "Fix or remove the file; refusing to overwrite it."
+            ) from error
+        return fallback.copy()
+
+    if not isinstance(value, dict):
+        if strict:
+            raise ConfigError(
+                f"{path} does not contain a JSON object; refusing to overwrite it."
+            )
+        return fallback.copy()
+    return value
 
 
 def seconds(value: Any, fallback: int, *, allow_off: bool = False) -> int:
@@ -64,7 +101,10 @@ def atomic_write(path: Path, value: dict[str, Any]) -> None:
 
 
 def current_config() -> dict[str, int]:
-    shell = read_json(shell_path(), {})
+    # shell.json belongs to Omarchy and holds unrelated settings, so it is read
+    # strictly. sandman.json is ours and fully derivable, so a damaged copy may
+    # be rebuilt from defaults.
+    shell = read_json(shell_path(), {}, strict=True)
     idle = shell.get("idle") if isinstance(shell.get("idle"), dict) else {}
     stored = read_json(config_path(), {})
     shell_screensaver = seconds(idle.get("screensaver"), DEFAULT_SCREENSAVER)
@@ -94,7 +134,7 @@ def initialize() -> dict[str, int]:
 
 
 def apply_idle_config(config: dict[str, int]) -> None:
-    shell = read_json(shell_path(), {"version": 1})
+    shell = read_json(shell_path(), {"version": 1}, strict=True)
     idle = shell.get("idle") if isinstance(shell.get("idle"), dict) else {}
     lock_timeout = config["lock"] if config["lock"] > 0 else OFF_TIMEOUT
     screensaver_timeout = (
@@ -112,7 +152,10 @@ def apply_idle_config(config: dict[str, int]) -> None:
 
 def set_screensaver(value: int) -> dict[str, int]:
     config = current_config()
-    config["screensaver"] = seconds(value, DEFAULT_SLEEP, allow_off=True)
+    # Fall back to the default, never to DEFAULT_SLEEP: with allow_off a 0
+    # fallback would turn an unusable value into "Off" and silently stand the
+    # screen saver down. Only an explicit 0 from the caller means Off.
+    config["screensaver"] = seconds(value, DEFAULT_SCREENSAVER, allow_off=True)
     apply_idle_config(config)
     atomic_write(config_path(), config)
     return config
@@ -120,7 +163,9 @@ def set_screensaver(value: int) -> dict[str, int]:
 
 def set_lock(value: int) -> dict[str, int]:
     config = current_config()
-    config["lock"] = seconds(value, DEFAULT_SLEEP, allow_off=True)
+    # Same reasoning as set_screensaver, and it matters more here: a 0 fallback
+    # would disable auto-lock on malformed input.
+    config["lock"] = seconds(value, DEFAULT_LOCK, allow_off=True)
     apply_idle_config(config)
     atomic_write(config_path(), config)
     return config
@@ -134,32 +179,54 @@ def set_sleep(value: int) -> dict[str, int]:
     return config
 
 
+def timeout(raw: str) -> int:
+    """Accept 0 (Off) or a positive timeout no larger than MAX_TIMEOUT.
+
+    Rejecting out-of-range values here keeps a bad number from reaching the
+    QML side, where the sleep timer multiplies seconds by 1000 into a 32-bit
+    int and would overflow past roughly 24 days.
+    """
+    try:
+        value = int(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"{raw!r} is not a whole number of seconds")
+    if value < 0:
+        raise argparse.ArgumentTypeError("timeout cannot be negative")
+    if value > MAX_TIMEOUT:
+        raise argparse.ArgumentTypeError(f"timeout cannot exceed {MAX_TIMEOUT} seconds")
+    return value
+
+
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     commands = result.add_subparsers(dest="command", required=True)
     commands.add_parser("init")
     commands.add_parser("get")
     screensaver = commands.add_parser("set-screensaver")
-    screensaver.add_argument("seconds", type=int)
+    screensaver.add_argument("seconds", type=timeout)
     lock = commands.add_parser("set-lock")
-    lock.add_argument("seconds", type=int)
+    lock.add_argument("seconds", type=timeout)
     sleep = commands.add_parser("set-sleep")
-    sleep.add_argument("seconds", type=int)
+    sleep.add_argument("seconds", type=timeout)
     return result
 
 
 def main() -> int:
     args = parser().parse_args()
-    if args.command == "init":
-        config = initialize()
-    elif args.command == "get":
-        config = current_config()
-    elif args.command == "set-screensaver":
-        config = set_screensaver(args.seconds)
-    elif args.command == "set-lock":
-        config = set_lock(args.seconds)
-    else:
-        config = set_sleep(args.seconds)
+    try:
+        if args.command == "init":
+            config = initialize()
+        elif args.command == "get":
+            config = current_config()
+        elif args.command == "set-screensaver":
+            config = set_screensaver(args.seconds)
+        elif args.command == "set-lock":
+            config = set_lock(args.seconds)
+        else:
+            config = set_sleep(args.seconds)
+    except ConfigError as error:
+        print(f"sandman: {error}", file=sys.stderr)
+        return 1
     print(json.dumps(config, separators=(",", ":")))
     return 0
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -36,9 +36,24 @@ test("requestedSeconds rejects unusable values instead of coercing to Off", () =
   assert.equal(model.requestedSeconds(900), 900);
 });
 
-test("requestedSeconds clamps below the 32-bit millisecond overflow", () => {
-  assert.equal(model.requestedSeconds(2000000000), model.maxTimeoutSeconds);
+test("requestedSeconds rejects oversized values rather than clamping them", () => {
+  // Clamping would turn an absurd setLock into a seven-day timeout, the same
+  // silent weakening this guard exists to prevent. Reject, as the CLI does.
+  assert.equal(model.requestedSeconds(2000000000), -1);
+  assert.equal(model.requestedSeconds(model.maxTimeoutSeconds + 1), -1);
+  assert.equal(model.requestedSeconds(model.maxTimeoutSeconds), model.maxTimeoutSeconds);
+});
+
+test("normalizedSeconds clamps persisted values below the 32-bit overflow", () => {
+  // A config written before the bounds existed has no caller to reject to.
+  assert.equal(model.normalizedSeconds(2000000000, 0, true), model.maxTimeoutSeconds);
   assert.ok(model.maxTimeoutSeconds * 1000 < 2147483647);
+});
+
+test("parseConfig bounds oversized persisted values", () => {
+  const parsed = model.parseConfig('{"screensaver":150,"lock":300,"sleep":2000000000}');
+  assert.equal(parsed.sleep, model.maxTimeoutSeconds);
+  assert.ok(parsed.sleep * 1000 < 2147483647);
 });
 
 test("statusSummary includes all stages", () => {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -27,6 +27,20 @@ test("formatDuration produces compact labels", () => {
   assert.equal(model.formatDuration(7200), "2 hours");
 });
 
+test("requestedSeconds rejects unusable values instead of coercing to Off", () => {
+  assert.equal(model.requestedSeconds(-5), -1);
+  assert.equal(model.requestedSeconds("nonsense"), -1);
+  assert.equal(model.requestedSeconds(Infinity), -1);
+  // 0 is only ever Off when the caller asks for it explicitly.
+  assert.equal(model.requestedSeconds(0), 0);
+  assert.equal(model.requestedSeconds(900), 900);
+});
+
+test("requestedSeconds clamps below the 32-bit millisecond overflow", () => {
+  assert.equal(model.requestedSeconds(2000000000), model.maxTimeoutSeconds);
+  assert.ok(model.maxTimeoutSeconds * 1000 < 2147483647);
+});
+
 test("statusSummary includes all stages", () => {
   assert.equal(
     model.statusSummary(300, 600, 1800),

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -39,6 +39,17 @@ class SandmanHelperTest(unittest.TestCase):
         )
         return json.loads(completed.stdout)
 
+    def run_helper_expecting_failure(self, *arguments):
+        completed = subprocess.run(
+            ["python3", str(HELPER), *arguments],
+            env=self.environment,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(completed.returncode, 0, completed.stdout)
+        return completed
+
     def test_init_inherits_omarchy_idle_settings_and_disables_sleep(self):
         expected = {"screensaver": 150, "lock": 300, "sleep": 0}
         self.assertEqual(self.run_helper("init"), expected)
@@ -94,6 +105,57 @@ class SandmanHelperTest(unittest.TestCase):
             {"screensaver": 150, "lock": 300, "sleep": 3600},
         )
         self.assertEqual(self.shell.read_text(), before)
+
+
+    def test_malformed_shell_config_is_left_intact(self):
+        self.run_helper("init")
+        damaged = '{"version": 1, "idle": {"lock": 300}, "bar": {"position": "top"},}'
+        self.shell.write_text(damaged, encoding="utf-8")
+
+        self.run_helper_expecting_failure("set-lock", "900")
+
+        self.assertEqual(self.shell.read_text(encoding="utf-8"), damaged)
+
+    def test_unreadable_shell_config_is_left_intact(self):
+        self.run_helper("init")
+        original = self.shell.read_text(encoding="utf-8")
+        self.shell.chmod(0o000)
+        try:
+            self.run_helper_expecting_failure("set-lock", "900")
+        finally:
+            self.shell.chmod(0o644)
+
+        self.assertEqual(self.shell.read_text(encoding="utf-8"), original)
+
+    def test_negative_timeout_is_rejected_rather_than_disabling_lock(self):
+        self.run_helper("init")
+
+        self.run_helper_expecting_failure("set-lock", "-5")
+
+        shell = json.loads(self.shell.read_text())
+        self.assertEqual(shell["idle"]["lock"], 300)
+        self.assertEqual(json.loads(self.config.read_text())["lock"], 300)
+
+    def test_absurd_timeout_is_rejected(self):
+        self.run_helper("init")
+
+        self.run_helper_expecting_failure("set-sleep", "2000000000")
+
+        self.assertEqual(json.loads(self.config.read_text())["sleep"], 0)
+
+    def test_missing_shell_config_still_initializes(self):
+        self.shell.unlink()
+        self.assertEqual(
+            self.run_helper("init"),
+            {"screensaver": 150, "lock": 300, "sleep": 0},
+        )
+
+    def test_damaged_sandman_config_is_rebuilt_from_shell(self):
+        self.config.write_text("{not json", encoding="utf-8")
+        self.assertEqual(
+            self.run_helper("init"),
+            {"screensaver": 150, "lock": 300, "sleep": 0},
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -107,6 +107,31 @@ class SandmanHelperTest(unittest.TestCase):
         self.assertEqual(self.shell.read_text(), before)
 
 
+    def test_invalid_utf8_shell_config_reports_cleanly_and_is_left_intact(self):
+        self.run_helper("init")
+        damaged = b'{"version": 1, "idle": {"lock": 300}, "x": "\xff\xfe"}'
+        self.shell.write_bytes(damaged)
+
+        completed = self.run_helper_expecting_failure("set-lock", "900")
+
+        # A controlled message, not a UnicodeDecodeError traceback.
+        self.assertIn("sandman:", completed.stderr)
+        self.assertNotIn("Traceback", completed.stderr)
+        self.assertEqual(self.shell.read_bytes(), damaged)
+
+    def test_oversized_persisted_value_is_bounded(self):
+        self.config.write_text(
+            json.dumps({"screensaver": 150, "lock": 300, "sleep": 2000000000}),
+            encoding="utf-8",
+        )
+
+        result = self.run_helper("init")
+
+        # Must stay under the 32-bit limit of sleepDelaySeconds * 1000.
+        self.assertEqual(result["sleep"], 7 * 24 * 60 * 60)
+        self.assertLess(result["sleep"] * 1000, 2**31 - 1)
+        self.assertEqual(json.loads(self.config.read_text())["sleep"], 7 * 24 * 60 * 60)
+
     def test_malformed_shell_config_is_left_intact(self):
         self.run_helper("init")
         damaged = '{"version": 1, "idle": {"lock": 300}, "bar": {"position": "top"},}'


### PR DESCRIPTION
Three related fixes where an error path silently weakened a setting or discarded user data. Found while reviewing the plugin before installing it; each is reproducible from a clean checkout and covered by a new test.

### 1. A malformed or unreadable `shell.json` was overwritten wholesale

`read_json` treats "file is missing" and "file could not be understood" identically, returning a fallback for both. Callers merge into that result and write it back, so a `shell.json` with a syntax error was replaced by a `{"version": 1}` stub — taking bar layout, widget order and plugin settings with it — while still exiting `0`:

```
bytes before: 235   (version, idle, bar layout, plugins)
bytes after:   76   ({"version":1,"idle":{...}})
exit code: 0
```

The `OSError` branch means the same happened to a perfectly valid file that briefly failed to read (I reproduced it with a momentary `chmod 000`). This is the one that worried me most, since hand-editing `shell.json` is the documented way to configure Omarchy.

Reads of `shell.json` are now strict: a missing file still defaults, but unreadable/malformed/non-object content raises `ConfigError` and the file is left untouched. `sandman.json` stays lenient, since it is fully derivable from `shell.json`.

### 2. Invalid input disabled auto-lock

`set_lock` and `set_screensaver` passed `DEFAULT_SLEEP` (`0`) as their fallback. Combined with `allow_off`, anything that failed to parse resolved to **Off**:

```
$ sandman.py set-lock -5
{"screensaver":150,"lock":0,"sleep":0}
--> shell.json idle: {'screensaver': 150, 'lock': 604800}
```

A bad value turned the screen lock off for seven days. They now fall back to `DEFAULT_LOCK` / `DEFAULT_SCREENSAVER` — both already defined — so only an explicit `0` from the caller means Off.

### 3. Unbounded timeouts overflow the sleep timer

`sleepTimer.interval` is `sleepDelaySeconds * 1000`, which exceeds a 32-bit int past roughly 24 days. The UI clamps via `Model.customSeconds`, but the CLI and IPC paths did not. A `timeout()` argparse type now bounds input to `[0, 604800]`, and `Model.requestedSeconds` applies the same check on the IPC path — returning `-1` for reject rather than `0`, so a rejected value cannot be read as Off.

### Also: a staleness backstop for screensaver windows

`handleIdleChanged` will not cancel the idle cycle while any window with class `org.omarchy.screensaver` is tracked. That class is self-reported by any client, and a `closewindow` event can be missed if the screensaver dies, so a tracked window could hold the sleep timer open after the user returned — suspending an active machine. Tracked windows now get five seconds to close before the cycle cancels regardless.

### Testing

Adds 6 Python and 2 JS regression tests. Full suite passes (`npm test`: 5 JS, 12 Python). Verified against a live install on Omarchy Quattro — plugin loads, IPC registers, `setLock -5` returns `false` and leaves config untouched, `setLock 900` applies normally, and the Off simulation still writes `screensaver: lock + 1`.

Happy to split this into separate PRs if you'd prefer them reviewed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
