### PR TITLE
Fix idle timeout changes without shell restart

### DIFF
--- a/Service.qml
+++ b/Service.qml
@@ -15,6 +15,7 @@ Item {
   property bool suspendPending: false
   property bool displaysOff: false
   property bool idleCycleRunning: false
+  property bool idleMonitorRearming: false
   property var screensaverWindows: ({})
   property int screensaverWindowCount: 0
 
@@ -82,6 +83,13 @@ Item {
 
   function refresh() {
     configFile.reload()
+  }
+
+  function rearmIdleMonitor() {
+    cancelIdleCycle()
+    if (!root.cycleEnabled) return
+    root.idleMonitorRearming = true
+    Qt.callLater(function() { root.idleMonitorRearming = false })
   }
 
   function resetScreensaverWindows() {
@@ -183,9 +191,12 @@ Item {
     suspendProcess.running = true
   }
 
-  onScreensaverSecondsChanged: cancelIdleCycle()
-  onDisplaySecondsChanged: cancelIdleCycle()
-  onSleepSecondsChanged: cancelIdleCycle()
+  // Quickshell's IdleMonitor does not re-register its idle notification when
+  // only `timeout` changes. Toggle it off and back on so changed settings take
+  // effect without requiring an omarchy-shell restart.
+  onScreensaverSecondsChanged: rearmIdleMonitor()
+  onDisplaySecondsChanged: rearmIdleMonitor()
+  onSleepSecondsChanged: rearmIdleMonitor()
 
   Process {
     id: initializeProcess
@@ -225,7 +236,7 @@ Item {
 
   IdleMonitor {
     id: idleMonitor
-    enabled: root.cycleEnabled
+    enabled: root.cycleEnabled && !root.idleMonitorRearming
     timeout: root.firstIdleSeconds
     respectInhibitors: true
     onIsIdleChanged: root.handleIdleChanged()

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "lgse.sandman",
   "name": "Sandman",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "Pierre Berube",
   "license": "MIT",
   "description": "Set when your screen rests, locks, and sleeps.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandman",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Set when your screen rests, locks, and sleeps.",
   "scripts": {

--- a/sandman.py
+++ b/sandman.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -142,21 +144,75 @@ def initialize() -> dict[str, int]:
     return config
 
 
-def apply_idle_config(config: dict[str, int]) -> None:
-    shell = read_json(shell_path(), {"version": 1}, strict=True)
-    idle = shell.get("idle") if isinstance(shell.get("idle"), dict) else {}
+def effective_idle_timeouts(config: dict[str, int]) -> tuple[int, int]:
     lock_timeout = config["lock"] if config["lock"] > 0 else OFF_TIMEOUT
     screensaver_timeout = (
         config["screensaver"]
         if config["screensaver"] > 0
         else lock_timeout + 1
     )
+    return screensaver_timeout, lock_timeout
+
+
+def apply_idle_config(config: dict[str, int]) -> None:
+    shell = read_json(shell_path(), {"version": 1}, strict=True)
+    idle = shell.get("idle") if isinstance(shell.get("idle"), dict) else {}
+    screensaver_timeout, lock_timeout = effective_idle_timeouts(config)
     shell["idle"] = {
         **idle,
         "screensaver": screensaver_timeout,
         "lock": lock_timeout,
     }
     atomic_write(shell_path(), shell)
+
+
+def rearm_native_idle(config: dict[str, int]) -> None:
+    """Re-register Omarchy's IdleMonitor after changing its timeout.
+
+    Quickshell currently leaves the old idle notification registered when only
+    IdleMonitor.timeout changes. Toggling an enabled service fixes that without
+    restarting the shell. Never override an intentional Stay Awake state.
+    """
+    if os.environ.get("OMARCHY_SHELL_CONFIG_PATH"):
+        return
+
+    screensaver_timeout, lock_timeout = effective_idle_timeouts(config)
+    for _ in range(20):
+        try:
+            completed = subprocess.run(
+                ["omarchy-shell", "idle", "status"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=1,
+            )
+            status = json.loads(completed.stdout)
+        except (FileNotFoundError, subprocess.SubprocessError, json.JSONDecodeError):
+            return
+
+        if not status.get("enabled", False):
+            return
+        if (
+            status.get("screensaver") == screensaver_timeout
+            and status.get("lock") == lock_timeout
+        ):
+            try:
+                subprocess.run(
+                    ["omarchy-shell", "idle", "disable"],
+                    check=True,
+                    capture_output=True,
+                    timeout=1,
+                )
+                subprocess.run(
+                    ["omarchy-shell", "idle", "enable"],
+                    check=True,
+                    capture_output=True,
+                    timeout=1,
+                )
+            except (FileNotFoundError, subprocess.SubprocessError):
+                pass
+            return
+        time.sleep(0.05)
 
 
 def set_screensaver(value: int) -> dict[str, int]:
@@ -167,6 +223,7 @@ def set_screensaver(value: int) -> dict[str, int]:
     config["screensaver"] = seconds(value, DEFAULT_SCREENSAVER, allow_off=True)
     apply_idle_config(config)
     atomic_write(config_path(), config)
+    rearm_native_idle(config)
     return config
 
 
@@ -177,6 +234,7 @@ def set_lock(value: int) -> dict[str, int]:
     config["lock"] = seconds(value, DEFAULT_LOCK, allow_off=True)
     apply_idle_config(config)
     atomic_write(config_path(), config)
+    rearm_native_idle(config)
     return config
 
 


### PR DESCRIPTION
## Summary
- rearm Sandman’s `IdleMonitor` when screen saver, display-off, or sleep timeouts change
- rearm Omarchy’s enabled idle service after screen saver or auto-lock changes while preserving Stay Awake
- bump Sandman from 0.7.0 to 0.7.1

## Why
Quickshell does not re-register an existing idle notification when only `IdleMonitor.timeout` changes. The panel and IPC status therefore showed the new timeout while the compositor still used the previous one until `omarchy restart shell`.

## Validation
- `npm test` (22 tests pass)
- `omarchy plugin validate .`
- reproduced with Screen Saver=5 minutes and Auto-lock=1 minute; verified the enabled native idle service is rearmed after applying the setting