### PR TITLE
[Security] Hardens hibernate configuration by moving privileged systemd configuration writes into a separately installed, root-owned helper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ qmllint -I "$OMARCHY_PATH/shell" BarWidget.qml Panel.qml Service.qml LidService.
 omarchy plugin remove lgse.sandman
 rm -f ~/.config/omarchy/sandman.json
 sudo rm -f /etc/systemd/sleep.conf.d/90-sandman.conf
+sudo rm -f /usr/local/libexec/sandman-configure-hibernate
 ```
 
 Removing Sandman does not revert the screen-saver and lock timeouts already written to `shell.json`. If Sandman is removed while a managed lid action is selected, remove the managed block between `-- BEGIN Sandman lid action override` and `-- END Sandman lid action override` from `~/.config/hypr/bindings.lua`, or reinstall Sandman and select **System default** before removing it.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ Each setting offers presets, Off, and a custom hours-and-minutes timeout. Omarch
 omarchy plugin add https://github.com/lgse/sandman.git --enable
 ```
 
+Install the privileged helper from the user-owned plugin checkout, then
+restart the shell if it is already running:
+
+```sh
+sudo install -D -o root -g root -m 0755 \
+  ~/.config/omarchy/plugins/lgse.sandman/sandman-configure-hibernate \
+  /usr/local/libexec/sandman-configure-hibernate
+omarchy restart shell
+```
+
 If needed, add it to the bar explicitly:
 
 ```sh
@@ -57,6 +67,9 @@ When **Hibernate after sleep** is enabled, Sandman instead requests `systemctl s
 - UPower
 - GLib (`gdbus`)
 - Polkit (`pkexec`), to change the systemd hibernate delay
+
+The helper is deliberately separate from `sandman.py`, because the latter is
+loaded from the user-owned plugin directory and must never be executed as root.
 
 ## Validate
 

--- a/Service.qml
+++ b/Service.qml
@@ -55,6 +55,8 @@ Item {
     var url = String(Qt.resolvedUrl("sandman.py"))
     return decodeURIComponent(url.indexOf("file://") === 0 ? url.substring(7) : url)
   }
+  // This helper is installed root-owned; never execute plugin code through pkexec.
+  readonly property string hibernateHelperPath: "/usr/local/libexec/sandman-configure-hibernate"
 
   function runHelper(arguments) {
     if (settingsProcess.running || hibernateConfigProcess.running) return false
@@ -104,7 +106,7 @@ Item {
     root.saving = true
     root.lastError = ""
     root.pendingHibernateSeconds = value
-    hibernateConfigProcess.command = ["pkexec", "python3", root.helperPath,
+    hibernateConfigProcess.command = ["pkexec", root.hibernateHelperPath,
       "configure-hibernate", String(value)]
     hibernateConfigProcess.running = true
     return true

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "lgse.sandman",
   "name": "Sandman",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": "Pierre Berube",
   "license": "MIT",
   "description": "Set lid-close actions and when your screen rests, locks, sleeps, and hibernates.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sandman",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "description": "Set lid-close actions and when your screen rests, locks, sleeps, and hibernates.",
   "scripts": {

--- a/sandman-configure-hibernate
+++ b/sandman-configure-hibernate
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+"""Privileged systemd sleep drop-in writer for Sandman."""
+
+import argparse
+import os
+import tempfile
+from pathlib import Path
+
+
+MAX_TIMEOUT = 7 * 24 * 60 * 60
+CONFIG = Path("/etc/systemd/sleep.conf.d/90-sandman.conf")
+
+
+def seconds(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("seconds must be a whole number") from error
+    if value < 0 or value > MAX_TIMEOUT:
+        raise argparse.ArgumentTypeError(
+            f"seconds must be between 0 and {MAX_TIMEOUT}"
+        )
+    return value
+
+
+def main() -> int:
+    if os.geteuid() != 0:
+        raise SystemExit("administrator authorization is required")
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("configure-hibernate",))
+    parser.add_argument("seconds", type=seconds)
+    args = parser.parse_args()
+
+    if args.seconds == 0:
+        CONFIG.unlink(missing_ok=True)
+        return 0
+
+    CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{CONFIG.name}.", dir=CONFIG.parent)
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            stream.write(
+                "[Sleep]\n"
+                f"HibernateDelaySec={args.seconds}s\n"
+                "HibernateOnACPower=yes\n"
+            )
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temporary_path, 0o644)
+        os.replace(temporary_path, CONFIG)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sandman.py
+++ b/sandman.py
@@ -57,8 +57,7 @@ def hypr_bindings_path() -> Path:
 
 
 def systemd_sleep_config_path() -> Path:
-    override = os.environ.get("SANDMAN_SYSTEMD_SLEEP_CONFIG_PATH")
-    return Path(override).expanduser() if override else SYSTEMD_SLEEP_CONFIG
+    return SYSTEMD_SLEEP_CONFIG
 
 
 def diagnostic_path(environment_name: str, default: str) -> Path:
@@ -437,11 +436,12 @@ def configure_hibernate(value: int) -> None:
     """Set systemd's suspend-then-hibernate delay.
 
     systemd owns the RTC wake alarm needed while the computer is suspended, so
-    this drop-in is necessarily system-wide. The normal UI invokes this command
-    through pkexec. Tests may redirect the path without requiring privileges.
+    this drop-in is necessarily system-wide. The normal UI invokes a separately
+    installed, root-owned helper through pkexec. This development helper never
+    redirects its privileged write through the environment.
     """
     path = systemd_sleep_config_path()
-    if not os.environ.get("SANDMAN_SYSTEMD_SLEEP_CONFIG_PATH") and os.geteuid() != 0:
+    if os.geteuid() != 0:
         raise ConfigError("administrator authorization is required to change the hibernate delay")
     try:
         if value == 0:

--- a/test/test_configure_hibernate.py
+++ b/test/test_configure_hibernate.py
@@ -1,0 +1,102 @@
+import argparse
+import importlib.machinery
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER_PATH = ROOT / "sandman-configure-hibernate"
+
+
+def load_helper():
+    """Import the privileged helper, which has no .py extension."""
+    loader = importlib.machinery.SourceFileLoader(
+        "sandman_configure_hibernate", str(HELPER_PATH)
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+class SecondsValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.helper = load_helper()
+
+    def test_accepts_zero_and_positive_within_limit(self):
+        self.assertEqual(self.helper.seconds("0"), 0)
+        self.assertEqual(self.helper.seconds("7200"), 7200)
+        self.assertEqual(
+            self.helper.seconds(str(self.helper.MAX_TIMEOUT)),
+            self.helper.MAX_TIMEOUT,
+        )
+
+    def test_rejects_non_integer(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            self.helper.seconds("later")
+
+    def test_rejects_negative(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            self.helper.seconds("-1")
+
+    def test_rejects_above_maximum(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            self.helper.seconds(str(self.helper.MAX_TIMEOUT + 1))
+
+
+class ConfigureHibernateMainTest(unittest.TestCase):
+    def setUp(self):
+        self.helper = load_helper()
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.config = Path(temporary.name) / "sleep.conf.d" / "90-sandman.conf"
+
+    def run_main(self, *arguments, euid=0):
+        argv = ["sandman-configure-hibernate", *arguments]
+        with mock.patch.object(self.helper, "CONFIG", self.config), \
+                mock.patch("os.geteuid", return_value=euid), \
+                mock.patch.object(sys, "argv", argv):
+            return self.helper.main()
+
+    def test_requires_root(self):
+        with self.assertRaises(SystemExit) as context:
+            self.run_main("configure-hibernate", "7200", euid=1000)
+        self.assertIn("administrator authorization is required", str(context.exception))
+        self.assertFalse(self.config.exists())
+
+    def test_writes_dropin_with_expected_content_and_mode(self):
+        self.assertEqual(self.run_main("configure-hibernate", "7200"), 0)
+        self.assertEqual(
+            self.config.read_text(encoding="utf-8"),
+            "[Sleep]\nHibernateDelaySec=7200s\nHibernateOnACPower=yes\n",
+        )
+        self.assertEqual(self.config.stat().st_mode & 0o777, 0o644)
+
+    def test_write_leaves_no_temporary_file_behind(self):
+        self.run_main("configure-hibernate", "7200")
+        siblings = [entry.name for entry in self.config.parent.iterdir()]
+        self.assertEqual(siblings, [self.config.name])
+
+    def test_zero_removes_existing_dropin(self):
+        self.config.parent.mkdir(parents=True)
+        self.config.write_text("stale\n", encoding="utf-8")
+        self.assertEqual(self.run_main("configure-hibernate", "0"), 0)
+        self.assertFalse(self.config.exists())
+
+    def test_zero_without_existing_dropin_is_noop(self):
+        self.assertEqual(self.run_main("configure-hibernate", "0"), 0)
+        self.assertFalse(self.config.exists())
+
+    def test_out_of_range_seconds_exits_without_writing(self):
+        with self.assertRaises(SystemExit) as context:
+            self.run_main("configure-hibernate", str(self.helper.MAX_TIMEOUT + 1))
+        self.assertNotEqual(context.exception.code, 0)
+        self.assertFalse(self.config.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -164,14 +164,8 @@ class SandmanHelperTest(unittest.TestCase):
         self.assertEqual(self.shell.read_text(), before)
 
     def test_configure_hibernate_writes_and_removes_systemd_dropin(self):
-        self.run_helper("configure-hibernate", "7200")
-        self.assertEqual(
-            self.systemd_sleep_config.read_text(),
-            "[Sleep]\nHibernateDelaySec=7200s\nHibernateOnACPower=yes\n",
-        )
-
-        self.run_helper("configure-hibernate", "0")
-
+        completed = self.run_helper_expecting_failure("configure-hibernate", "7200")
+        self.assertIn("administrator authorization is required", completed.stderr)
         self.assertFalse(self.systemd_sleep_config.exists())
 
     def test_display_only_changes_sandman_state(self):


### PR DESCRIPTION
Security improvements:
- Prevents pkexec from executing Python code from the user-owned plugin directory.
- Uses a fixed root-owned helper at /usr/local/libexec/sandman-configure-hibernate.
- Removes the environment-variable override for the privileged systemd config path.
- Requires administrator privileges for hibernate configuration changes.
- Validates timeout values from 0 to 7 days.
- Writes configuration atomically using a temporary file, fsync, and os.replace.
- Supports safely removing the drop-in when hibernation delay is disabled.
- Updates tests and documents the helper installation process.